### PR TITLE
Allow user to return void in registered action-callback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,10 @@ import { Middleware, MiddlewareAPI } from 'redux';
 
 export type GetState = () => any;
 
-export type PayloadCallback<A> = (action: any, getState: GetState) => A;
+export type PayloadCallback<A> = (
+  action: any,
+  getState: GetState
+) => A | void | undefined | null;
 
 export type Payload<A> = PayloadCallback<A> | A;
 
@@ -105,7 +108,9 @@ export default class ReduxAnalyticsManager<A> {
         payload = payload(action, this.store.getState) as A;
       }
 
-      this.send(payload);
+      if (payload) {
+        this.send(payload);
+      }
     });
   }
 }

--- a/test/analytics-manager.ts
+++ b/test/analytics-manager.ts
@@ -18,7 +18,8 @@ const spies: Spies = {
       if (Object.keys(data).length) { return data; }
       return action.data;
     }
-  )
+  ),
+  registerSpy5: spy()
 };
 
 function resetSpyHistory() {
@@ -36,7 +37,8 @@ function createAnalyticsMiddleware(): Middleware {
     Util.ACTION3, [
     Util.analyticsObject1, spies.registerSpy3]
   );
-  manager.registerAction(Util.SET_DATA, spies.registerSpy4);
+  manager.registerAction(Util.ACTION4, spies.registerSpy4);
+  manager.registerAction(Util.ACTION5, spies.registerSpy5);
   return manager.createMiddleware();
 }
 
@@ -106,20 +108,29 @@ describe('Redux Analytics Manager - Functionality', function() {
       eventLabel: 'fake-label'
     };
     const data2 = Util.analyticsObject4;
-    await this.store.dispatch(Util.setData(data1));
-    await this.store.dispatch(Util.setData(data2));
+    await this.store.dispatch(Util.actionCreator4(data1));
+    await this.store.dispatch(Util.actionCreator4(data2));
     chai.expect(sendSpy.firstCall.args[0]).to.deep.equal(data1);
     chai.expect(sendSpy.lastCall.args[0]).to.deep.equal(data1);
   });
 
   it(
-    'does\'t call sendMethod or registered callbacks on non-registered actions',
+    'doesn\'t call sendMethod or registered callbacks on non-registered actions',
     async function() {
       await this.store.dispatch({type: 'unregistered'});
       chai.expect(spies.sendSpy.calledOnce).to.be.false;
       chai.expect(spies.registerSpy2.calledOnce).to.be.false;
       chai.expect(spies.registerSpy3.calledOnce).to.be.false;
       chai.expect(spies.registerSpy4.calledOnce).to.be.false;
+    }
+  );
+
+  it (
+    'allows user to return void in registered action-callback',
+    async function() {
+      await this.store.dispatch(Util.actionCreator5());
+      chai.expect(spies.registerSpy5.calledOnce).to.be.true;
+      chai.expect(spies.sendSpy.calledOnce).to.be.false;
     }
   );
 });

--- a/test/util/index.ts
+++ b/test/util/index.ts
@@ -18,7 +18,8 @@ interface State {
 export const ACTION1 = 'ACTION1';
 export const ACTION2 = 'ACTION2';
 export const ACTION3 = 'ACTION3';
-export const SET_DATA = 'SET_DATA';
+export const ACTION4 = 'ACTION4';
+export const ACTION5 = 'ACTION5';
 
 export const analyticsObject1: IAnalytics = {
   eventCategory: 'Category1',
@@ -44,6 +45,12 @@ export const analyticsObject4: IAnalytics = {
   eventLabel: 'Label4'
 }
 
+export const analyticsObject5: IAnalytics = {
+  eventCategory: 'Category5',
+  eventAction: 'Action5',
+  eventLabel: 'Label5'
+}
+
 export function actionCreator1(): IAnalyticsAction {
   return {
     type: ACTION1,
@@ -65,16 +72,23 @@ export function actionCreator3(): IAnalyticsAction {
   };
 }
 
-export function setData(data: IAnalytics): IAnalyticsAction {
+export function actionCreator4(data: IAnalytics): IAnalyticsAction {
   return {
-    type: SET_DATA,
+    type: ACTION4,
     data
-  }
+  };
+}
+
+export function actionCreator5(): IAnalyticsAction {
+  return {
+    type: ACTION5,
+    data: analyticsObject5
+  };
 }
 
 function reducer(state: State = {data: {}}, action: AnyAction) {
   switch (action.type) {
-    case SET_DATA:
+    case ACTION4:
       return {data: action.data};
     default:
       return state;


### PR DESCRIPTION
If nothing is returned in registered callback the send method
will not be called