### PR TITLE
Use event emitter and provide callbacks more info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: node_js
 node_js:
   - "8"
 script:
-  - npm run build
-  - npm run test
+  - npm run prepublishOnly
 branches:
   only:
     - master

--- a/test/analytics-manager.ts
+++ b/test/analytics-manager.ts
@@ -4,22 +4,27 @@ import { spy, SinonSpy } from 'sinon';
 import * as Util from './util';
 import * as AnalyticsManager from '../src';
 
+const ReduxAnalyticsManager = AnalyticsManager.ReduxAnalyticsManager;
+
 interface Spies {
   [key: string]: SinonSpy;
 }
 
 const spies: Spies = {
+  registerSpy0: spy(),
   sendSpy: spy(),
-  registerSpy2: spy(function() {return Util.analyticsObject2}),
-  registerSpy3: spy(function() {return Util.analyticsObject3}),
+  registerSpy2: spy(() => Util.analyticsObject2),
+  registerSpy3: spy(() => Util.analyticsObject3),
   registerSpy4: spy(
-    function(action: AnyAction, getState: AnalyticsManager.GetState) {
-      const data = getState().data;
-      if (Object.keys(data).length) { return data; }
-      return action.data;
+    (action: AnyAction, currState: Util.State, nextState: Util.State) => {
+      return currState.data;
     }
   ),
-  registerSpy5: spy()
+  registerSpy5: spy(
+    (action: AnyAction, currState: Util.State, nextState: Util.State) => {
+      return nextState.data;
+    }
+  )
 };
 
 function resetSpyHistory() {
@@ -29,8 +34,9 @@ function resetSpyHistory() {
 }
 
 function createAnalyticsMiddleware(): Middleware {
-  const manager = new AnalyticsManager.default<Util.IAnalytics>();
+  const manager = new ReduxAnalyticsManager<Util.IAnalytics, Util.State>();
   manager.setSendMethod(spies.sendSpy);
+  manager.registerAction(Util.ACTION0, spies.registerSpy0);
   manager.registerAction(Util.ACTION1, Util.analyticsObject1);
   manager.registerAction(Util.ACTION2, spies.registerSpy2);
   manager.registerAction(
@@ -51,7 +57,7 @@ describe('Redux Analytics Manager - Functionality', function() {
   });
 
   it(
-    'calls send method with analytics object and redux getState method ' +
+    'calls send method with analytics object and current state ' +
     '- registered object',
     async function() {
       const sendSpy = spies.sendSpy;
@@ -59,12 +65,12 @@ describe('Redux Analytics Manager - Functionality', function() {
       await this.store.dispatch(Util.actionCreator1());
       chai.expect(sendSpy.calledOnce).to.be.true;
       chai.expect(sendSpy.lastCall.args[0]).to.deep.equal(analyticObj1);
-      chai.expect(sendSpy.lastCall.args[1].name).to.equal('getState');
+      chai.expect(sendSpy.lastCall.args[1]).to.deep.equal(Util.initialState);
     }
   );
 
   it(
-    'calls send method with analytics object and redux getState method ' +
+    'calls send method with analytics object and current state ' +
     '- registerd callback',
     async function() {
       const sendSpy = spies.sendSpy;
@@ -72,18 +78,25 @@ describe('Redux Analytics Manager - Functionality', function() {
       await this.store.dispatch(Util.actionCreator2());
       chai.expect(sendSpy.calledOnce).to.be.true;
       chai.expect(sendSpy.lastCall.args[0]).to.deep.equal(analyticObj2);
-      chai.expect(sendSpy.lastCall.args[1].name).to.equal('getState');
+      chai.expect(sendSpy.lastCall.args[1]).to.deep.equal(Util.initialState);
     }
   );
 
   it(
-    'calls registered action callback with action and getState method',
+    'calls registered action callback with action, currState, and nextState',
     async function() {
       const registerSpy2 = spies.registerSpy2;
+      const analyticObj2 = Util.analyticsObject2;
       const action2 = Util.actionCreator2();
       await this.store.dispatch(action2);
       chai.expect(registerSpy2.calledOnce).to.be.true;
       chai.expect(registerSpy2.lastCall.args[0]).to.deep.equal(action2);
+      chai.expect(registerSpy2.lastCall.args[1]).to.deep.equal(
+        Util.initialState
+      );
+      chai.expect(registerSpy2.lastCall.args[2]).to.deep.equal(
+        {data: analyticObj2}
+      );
     }
   );
 
@@ -100,22 +113,27 @@ describe('Redux Analytics Manager - Functionality', function() {
     chai.expect(sendSpy.lastCall.args[0]).to.deep.equal(analyticObj3);
   });
 
-  it('gives user access to state in registered callback', async function() {
-    const sendSpy = spies.sendSpy;
-    const data1 = {
-      eventCategory: 'fake-category',
-      eventAction: 'fake-action',
-      eventLabel: 'fake-label'
-    };
-    const data2 = Util.analyticsObject4;
-    await this.store.dispatch(Util.actionCreator4(data1));
-    await this.store.dispatch(Util.actionCreator4(data2));
-    chai.expect(sendSpy.firstCall.args[0]).to.deep.equal(data1);
-    chai.expect(sendSpy.lastCall.args[0]).to.deep.equal(data1);
-  });
+  it('gives user access to currState in registered callback',
+    async function() {
+      const sendSpy = spies.sendSpy;
+      await this.store.dispatch(Util.actionCreator4());
+      chai.expect(
+        sendSpy.firstCall.args[0]
+      ).to.deep.equal(Util.initialState.data);
+    }
+  );
+
+  it('gives user access to nextState in registered callback',
+    async function() {
+      const sendSpy = spies.sendSpy;
+      const analytics = Util.analyticsObject5;
+      await this.store.dispatch(Util.actionCreator5());
+      chai.expect(sendSpy.firstCall.args[0]).to.deep.equal(analytics);
+    }
+  );
 
   it(
-    'doesn\'t call sendMethod or registered callbacks on non-registered actions',
+    'doesn\'t call sendMethod or registered callbacks on unregistered actions',
     async function() {
       await this.store.dispatch({type: 'unregistered'});
       chai.expect(spies.sendSpy.calledOnce).to.be.false;
@@ -126,10 +144,10 @@ describe('Redux Analytics Manager - Functionality', function() {
   );
 
   it (
-    'allows user to return void in registered action-callback',
+    'doesn\'t call send if action callback returns void',
     async function() {
-      await this.store.dispatch(Util.actionCreator5());
-      chai.expect(spies.registerSpy5.calledOnce).to.be.true;
+      await this.store.dispatch(Util.actionCreator0());
+      chai.expect(spies.registerSpy0.calledOnce).to.be.true;
       chai.expect(spies.sendSpy.calledOnce).to.be.false;
     }
   );
@@ -139,7 +157,7 @@ describe('Redux Analytics Manager - Errors', function() {
   it(
     'throws if createMiddleware is called without registering actions',
     function() {
-      const manager = new AnalyticsManager.default<Util.IAnalytics>();
+      const manager = new ReduxAnalyticsManager<Util.IAnalytics, Util.State>();
       manager.setSendMethod(() => console.log('send method set'));
       chai.expect(manager.createMiddleware.bind(manager)).to.throw();
     }
@@ -148,8 +166,8 @@ describe('Redux Analytics Manager - Errors', function() {
   it(
     'throws if createMiddleware is called without setting send method',
     function() {
-      const manager = new AnalyticsManager.default();
-      manager.registerAction('Whatever', {data: 'data'});
+      const manager = new ReduxAnalyticsManager<Util.IAnalytics, Util.State>();
+      manager.registerAction('Whatever', Util.analyticsObject1);
       chai.expect(manager.createMiddleware.bind(manager)).to.throw();
     }
   );
@@ -157,9 +175,9 @@ describe('Redux Analytics Manager - Errors', function() {
   it(
     'throws if createMiddleware is called more than once',
     function() {
-      const manager = new AnalyticsManager.default();
+      const manager = new ReduxAnalyticsManager<Util.IAnalytics, Util.State>();
       manager.setSendMethod(function() {});
-      manager.registerAction('Whatever', {data: 'data'});
+      manager.registerAction('Whatever', Util.analyticsObject1);
       const middleware = manager.createMiddleware();
       const store = Util.setUpStore(middleware);
       store.dispatch({type: 'Whatever'});
@@ -170,7 +188,7 @@ describe('Redux Analytics Manager - Errors', function() {
   it(
     'throws if setSendMethod is called more than once',
     function() {
-      const manager = new AnalyticsManager.default();
+      const manager = new ReduxAnalyticsManager<Util.IAnalytics, Util.State>();
       manager.setSendMethod(() => console.log('send method set'));
       chai.expect(manager.setSendMethod.bind(manager)).to.throw();
     }

--- a/test/util/index.ts
+++ b/test/util/index.ts
@@ -11,15 +11,22 @@ interface IAnalyticsAction {
   data: IAnalytics;
 }
 
-interface State {
-  data: IAnalytics | {};
+export interface State {
+  data: IAnalytics;
 }
 
+export const ACTION0 = 'ACTION0';
 export const ACTION1 = 'ACTION1';
 export const ACTION2 = 'ACTION2';
 export const ACTION3 = 'ACTION3';
 export const ACTION4 = 'ACTION4';
 export const ACTION5 = 'ACTION5';
+
+export const analyticsObject0: IAnalytics = {
+  eventCategory: 'Category0',
+  eventAction: 'Action0',
+  eventLabel: 'Label0'
+}
 
 export const analyticsObject1: IAnalytics = {
   eventCategory: 'Category1',
@@ -51,6 +58,13 @@ export const analyticsObject5: IAnalytics = {
   eventLabel: 'Label5'
 }
 
+export function actionCreator0(): IAnalyticsAction {
+  return {
+    type: ACTION0,
+    data: analyticsObject0
+  };
+}
+
 export function actionCreator1(): IAnalyticsAction {
   return {
     type: ACTION1,
@@ -72,10 +86,10 @@ export function actionCreator3(): IAnalyticsAction {
   };
 }
 
-export function actionCreator4(data: IAnalytics): IAnalyticsAction {
+export function actionCreator4(): IAnalyticsAction {
   return {
     type: ACTION4,
-    data
+    data: analyticsObject4
   };
 }
 
@@ -86,15 +100,13 @@ export function actionCreator5(): IAnalyticsAction {
   };
 }
 
-function reducer(state: State = {data: {}}, action: AnyAction) {
-  switch (action.type) {
-    case ACTION4:
-      return {data: action.data};
-    default:
-      return state;
-  }
+export const initialState: State = {data: analyticsObject0};
+
+function reducer(state: State = initialState, action: AnyAction) {
+  if (!action.data) { return state; }
+  return {data: action.data};
 }
 
 export function setUpStore(middleware: Middleware) {
-  return createStore(reducer, {data: {}}, applyMiddleware(middleware));
+  return createStore(reducer, applyMiddleware(middleware));
 }


### PR DESCRIPTION
This patch includes a few improvements:
- use event emitter to listen for, and emit, registered action types
- no longer keeping entire store as class member and instead
  passing currState and nextState directly to registered callbacks
- similarly, provide registered send method with currState instead
  of the entire store
- removes default export as that seems to be best practice