### PR TITLE
Allow setSendMethod to be idempotent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,10 +39,6 @@ export class ReduxAnalyticsManager<A, S> {
   }
 
   public setSendMethod(fn: UserSendFunc<A, S>): void {
-    if (this.send) {
-      throw Error('Can only set analytics send method once');
-    }
-
     this.send = fn;
   }
 

--- a/test/analytics-manager.ts
+++ b/test/analytics-manager.ts
@@ -184,13 +184,4 @@ describe('Redux Analytics Manager - Errors', function() {
       chai.expect(manager.createMiddleware.bind(manager)).to.throw();
     }
   );
-
-  it(
-    'throws if setSendMethod is called more than once',
-    function() {
-      const manager = new ReduxAnalyticsManager<Util.IAnalytics, Util.State>();
-      manager.setSendMethod(() => console.log('send method set'));
-      chai.expect(manager.setSendMethod.bind(manager)).to.throw();
-    }
-  );
 });


### PR DESCRIPTION
Hey Rob,

I would propose that we allow this `sendMethod` to be overwritten, just for simplicity sake. Doesn't seem like there is any reason to prevent users from changing this method and it may catch people by surprise.

However, if there is a reason to prevent users from calling the `setSendMethod` multiple times, then maybe we should just add the reason to the README so users can expect this behavior and understand that `setSendMethod` can throw. 