### PR TITLE
Allow users to register and de-register actions on the fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,14 @@ current state, and the next state.
   object from the registered action along with the current state for further
   processing if necessary.
 - Register actions with either analytics objects, or callbacks. Callbacks are
-  passed the original action, the current state, and the next state. If the callback
-  doesn't return anything the send method won't be called.
+  passed the original action, the current state, and the next state. If the
+  callback doesn't return anything the send method won't be called.
 - Call the middleware create method
 
 If you register the same action more than once, the calls to your send method
-will occur in the order they were defined.
+will occur in the order they were defined. You can also use `registerActions`
+to register an array of actions to the same analytics object, callback, or a
+mixed array.
 
 ```javascript
 // Example using Google Analytics
@@ -37,7 +39,9 @@ const manager = new ReduxAnalyticsManager();
 ga('create', 'UA-XXXXX-Y', 'auto');
 
 function sendAnalytics(analyticObj, currState) {
-    ga('send', analyticsObj);
+    if (currState.analyticsEnabled) {
+        ga('send', analyticsObj);
+    }
 }
 
 manager.setSendMethod(sendAnalytics);
@@ -105,3 +109,26 @@ const analyticsMiddleware = manager.createMiddleware();
 const store = createStore(rootReducer, applyMiddleware(analyticsMiddlware));
 
 ```
+
+### Methods
+- **constructor:**
+    For typescript, pass an analytics object type and your appState type during
+    instantiation
+- **setSendMethod:**
+    User defined function that will be called with registered analytics object
+    or the returned analytics object from registered callback
+- **createMiddleware:**
+    Returns redux middleware to be used in the redux `applyMiddlware` method
+- **registerAction:**
+    Register a single action to an analytics object, callback, or mixed array
+    of either
+- **registerActions:**
+    Register an array of actions to an analytics object, callback, or a mixed
+    array of either
+- **deRegisterAction:**
+    Removes action listener and stops calling send method / callbacks for that
+    action
+- **deRegisterActions:**
+    Removes action listeners for an array of actions
+- **deRegisterAll:**
+    Removes all action listeners

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,14 +38,14 @@ export class ReduxAnalyticsManager<A, S> {
     this.initialized = false;
   }
 
-  public setSendMethod(fn: UserSendFunc<A, S>): void {
+  public setSendMethod = (fn: UserSendFunc<A, S>): void => {
     this.send = fn;
   }
 
-  public registerAction(
+  public registerAction = (
     type: string,
     payload: Payload<A, S> | Array<Payload<A, S>>
-  ): void {
+  ): void => {
 
     if (!this.payloads[type]) {
       this.payloads[type] = [];
@@ -60,25 +60,34 @@ export class ReduxAnalyticsManager<A, S> {
     this.listen(type);
   }
 
-  public registerActions(
+  public registerActions = (
     types: string[],
     payload: Payload<A, S> | Array<Payload<A, S>>
-  ): void {
+  ): void => {
     for (const type of types) {
       this.registerAction(type, payload);
     }
   }
 
-  public createMiddleware(): Middleware {
+  public deRegisterAction = (type: string): void => {
+    delete this.payloads[type];
+    this.emitter.removeListener(type, this.emitterCallback);
+  }
+
+  public deRegisterActions = (types: string[]): void => {
+    for (const type of types) {
+      this.deRegisterAction(type);
+    }
+  }
+
+  public deRegisterAll = (): void => {
+    this.payloads = {};
+    this.emitter.removeAllListeners();
+  }
+
+  public createMiddleware = (): Middleware => {
     if (this.initialized) {
       throw Error('Can only call createMiddlware once');
-    }
-
-    if (!Object.keys(this.payloads).length) {
-      throw Error(
-        'No analytics actions registered. Register actions before ' +
-        'calling createMiddleware'
-      );
     }
 
     if (!this.send) {
@@ -100,7 +109,7 @@ export class ReduxAnalyticsManager<A, S> {
       };
   }
 
-  private emitterCallback(data: EventCallbackObj<S>): void  {
+  private emitterCallback = (data: EventCallbackObj<S>): void  => {
     const type = data.action.type;
     this.payloads[type].forEach((payload: Payload<A, S>) => {
 
@@ -115,7 +124,7 @@ export class ReduxAnalyticsManager<A, S> {
   }
 
   private listen(type: string): void {
-    this.emitter.on(type, this.emitterCallback.bind(this));
+    this.emitter.on(type, this.emitterCallback);
   }
 }
 


### PR DESCRIPTION
Users can now use the createMiddleware method without having to
register actions first. Actions can then be registered, de-registered,
and re-registered at any time.